### PR TITLE
Updated color pallet to fix native theme support

### DIFF
--- a/sourcecode/main/res/values/colors.xml
+++ b/sourcecode/main/res/values/colors.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <color name="colorPrimary">#3F51B5</color>
-    <color name="colorPrimaryDark">#303F9F</color>
-    <color name="colorAccent">#FF4081</color>
+    <color name="colorPrimary">#8c1313</color>
+    <color name="colorPrimaryDark">#8c1313</color>
+    <color name="colorAccent">#101010</color>
 </resources>


### PR DESCRIPTION
Native theme was pulling from the colors.xml and coloring the status bar blue-

Looks awkward on pure AOSP 

https://developer.android.com/training/material/theme.html#StatusBar