### PR TITLE
Add warning on README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,6 @@
 # WiFi Bruteforcer - Fsecurify
+**WARNING:** This project is still under development and by installing the app may desconfigure the Wi-Fi settings of your Android OS, a system restore may be necessary to fix it.
+
 Android application to brute force WiFi passwords without requiring a rooted device.
 
 ![Alt text](1280.jpg?raw=true "Fsecurify")


### PR DESCRIPTION
I installed `wifi_bruteforcer_fsecurify_6.0.apk` on my phone and that caused many issues afterwards (after first the scan ~8000 words), the issues are not being able to connect to Wi-Fi and some random freezes (even after the app was uninstalled), and I realized in the comments/issues many people had the same problem, so it's VERY irresponsible to leave it like that for public download, since the current state of the project is a MALWARE.

Love the premise of the project, keep up the good work, after the project is stable just remove the warning.